### PR TITLE
Make the decorator a little friendlier to the wrapped client

### DIFF
--- a/swagger_zipkin/decorate_client.py
+++ b/swagger_zipkin/decorate_client.py
@@ -5,6 +5,31 @@ from __future__ import unicode_literals
 import functools
 
 
+class OperationDecorator(object):
+    """A helper to preserve attributes of :class:`swaggerpy.client.Operation`
+    and :class:`bravado.client.CallableOperation` while decorating their
+    __call__() methods
+
+    :param operation: callable operation, e.g., attributes of
+        :class:`swaggerpy.client.Resource` or
+        :class:`bravado_core.resource.Resource`
+    :type  operation: :class:`swaggerpy.client.Operation` or
+        :class:`bravado.client.CallableOperation`
+    :param func: a callable which accepts `*args`, `**kwargs`
+    :type  func: callable
+    """
+
+    def __init__(self, operation, func):
+        self.operation = operation
+        self.func = func
+
+    def __getattr__(self, name):
+        return getattr(self.operation, name)
+
+    def __call__(self, *args, **kwargs):
+        return self.func(*args, **kwargs)
+
+
 def decorate_client(api_client, func, name):
     """A helper for decorating :class:`bravado.client.SwaggerClient`.
     :class:`bravado.client.SwaggerClient` can be extended by creating a class
@@ -46,4 +71,4 @@ def decorate_client(api_client, func, name):
     if not callable(client_attr):
         return client_attr
 
-    return functools.partial(func, name)
+    return OperationDecorator(client_attr, functools.partial(func, name))

--- a/swagger_zipkin/zipkin_decorator.py
+++ b/swagger_zipkin/zipkin_decorator.py
@@ -44,3 +44,6 @@ class ZipkinClientDecorator(object):
 
     def __getattr__(self, name):
         return ZipkinResourceDecorator(getattr(self.client, name))
+
+    def __dir__(self):
+        return dir(self.client)  # pragma: no cover

--- a/tests/decorate_client_test.py
+++ b/tests/decorate_client_test.py
@@ -21,3 +21,38 @@ def test_decorate_client_non_callable():
 
     decorated = decorate_client(client, mock.Mock(), 'attr')
     assert client.attr == decorated
+
+
+def test_decorate_client_callable_being_invoked():
+    def foo(a, b, c):
+        pass
+
+    client = mock.Mock()
+    client.attr = foo
+    decorated_foo = mock.Mock()
+
+    decorated_callable = decorate_client(client, decorated_foo, 'attr')
+    assert decorated_callable.operation == foo
+
+    # Ensure that it's `decorated_foo` being called, not `foo`
+    decorated_callable()
+    decorated_foo.assert_called_once_with('attr')
+
+
+def test_decorate_client_callable_attribute_retrieved():
+    class Foo(object):
+        def __init__(self):
+            self.bar = 'bar'
+
+        def __call__(self, a, b, c):
+            return a + b + c
+
+    client = mock.Mock()
+    client.attr = Foo()
+    decorated_foo = mock.Mock(return_value=100)
+    decorated_callable = decorate_client(client, decorated_foo, 'attr')
+
+    # `decorated_foo` is called, not `Foo().__call__`
+    assert decorated_callable(2, 3, 7) == 100
+    # Foo().bar is accessible after it is decorated
+    assert decorated_callable.bar == 'bar'


### PR DESCRIPTION
These are updates to bring `swagger_zipkin` into parity with the internal copy of this wrapper in `bravado_decorators`.
