### PR TITLE
Don't clobber stacktrace, just let the AttributeError raise

### DIFF
--- a/swagger_zipkin/decorate_client.py
+++ b/swagger_zipkin/decorate_client.py
@@ -64,9 +64,6 @@ def decorate_client(api_client, func, name):
     :returns: the attribute from the `api_client` or a partial of `func`
     :raises: :class:`AttributeError`
     """
-    if not hasattr(api_client, name):
-        raise AttributeError(name)
-
     client_attr = getattr(api_client, name)
     if not callable(client_attr):
         return client_attr


### PR DESCRIPTION
This was hiding the underlying error in a stacktrace of ours.

The new line 67 will raise anyway if the attribute is not there.  `getattr` unlike `dict#get` raises when not present.
