### PR TITLE
Remove unneeded coverage combine that caused coverage >= 4.3 builds t…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 env:
-- TOX_ENV=py26
 - TOX_ENV=py27
 - TOX_ENV=py33
 - TOX_ENV=py34

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ deps = -rrequirements-dev.txt
 commands =
     coverage erase
     coverage run --source=swagger_zipkin/ -m pytest --strict {posargs}
-    coverage combine --append
     coverage report -m --show-missing --fail-under 100
 
 [testenv:docs]


### PR DESCRIPTION
Also removed py26 from travis config. We're not testing against it in tox any more.