### PR TITLE
add REPL completion for resource

### DIFF
--- a/swagger_zipkin/zipkin_decorator.py
+++ b/swagger_zipkin/zipkin_decorator.py
@@ -27,6 +27,9 @@ class ZipkinResourceDecorator(object):
         headers.update(create_http_headers_for_new_span())
         return getattr(self.resource, call_name)(*args, **kwargs)
 
+    def __dir__(self):
+        return dir(self.resource)
+
 
 class ZipkinClientDecorator(object):
     """A wrapper to swagger client (swagger-py or bravado) to pass on zipkin

--- a/tests/zipkin_decorator_test.py
+++ b/tests/zipkin_decorator_test.py
@@ -57,3 +57,18 @@ def test_client_request_option_decorator():
             param,
             _request_options=create_request_options(trace_id, 'span2', span_id)
         )
+
+
+def test_client_dir():
+    class V1Operation():
+        def foo():
+            return 'foo'
+
+    class Client(object):
+        def __init__(self):
+            self.v1 = V1Operation()
+
+    client = Client()
+    wrapped_client = ZipkinClientDecorator(client)
+
+    assert 'foo' in dir(wrapped_client.v1)


### PR DESCRIPTION
Added iPython tab completion for client resource.

```python
client = SwaggerClient.from_url('http://petstore.swagger.io/v2/swagger.json')
wrapped_client = ZipkinClientDecorator(client)
```

After typing `wrapped_client.pet.<TAB>`

**Before:** Completes with `with_headers` which is technically a private decorator function. We had to use `wrapped_client.pet.resource.<TAB>` to obtain the list of swagger operations. This was due to the fact that `__getattr__` was set, but `__dir__` was not set.

**After:** Completes with `.addPet`, `.getPetById`, etc. These are the functions we want to expose.

### Testing

`make test` passes and also manually tested with a SwaggerClient.
