### PR TITLE
Remove py34 and add py37 to tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: python
+# sudo and xenial are required to install py37
+# https://github.com/travis-ci/travis-ci/issues/9069
+sudo: required
+dist: xenial
+
 matrix:
   include:
   - python: 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,15 @@ matrix:
   include:
   - python: 2.7
     env: TOXENV=py27
-  - python: 3.4
-    env: TOXENV=py34
   - python: 3.5
     env: TOXENV=py35
   - python: 3.6
     env: TOXENV=py36
-  - python: 3.6
+  - python: 3.7
+    env: TOXENV=py37
+  - python: 3.7
     env: TOXENV=flake8
-  - python: 3.6
+  - python: 3.7
     env: TOXENV=pre-commit
 install:
 - pip install tox coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pre-commit, py27, py34, py35, py36, flake8
+envlist = pre-commit, py27, py35, py36, py37, flake8
 
 [testenv]
 deps = -rrequirements-dev.txt
@@ -9,7 +9,7 @@ commands =
     coverage report -m --show-missing --fail-under 100
 
 [testenv:docs]
-basepython = python3.6
+basepython = python3.7
 deps =
     {[testenv]deps}
     sphinx
@@ -17,12 +17,12 @@ changedir = docs
 commands = sphinx-build -b html -d build/doctrees source build/html
 
 [testenv:pre-commit]
-basepython = python3.6
+basepython = python3.7
 deps = -rrequirements-dev.txt
 commands = pre-commit run --all-files
 
 [testenv:flake8]
-basepython = python3.6
+basepython = python3.7
 deps = flake8
 commands =
     flake8 swagger_zipkin tests


### PR DESCRIPTION
py34 has reached EOL. Let's remove it and add py37 to the list of python
versions we test against.

This doesn't mean swagger_zipkin won't work on py34 anymore, just that we
don't test against it and that we don't guarantee compatibility anymore.