### PR TITLE
otel instrumentation for outgoing calls using generated clientlibs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     python_requires=">=3.7",
     install_requires=[
         'py_zipkin>=0.10.1',
+        'opentelemetry-sdk>=0.26.1',
     ],
     keywords='zipkin',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     install_requires=[
         'py_zipkin>=0.10.1',
         'opentelemetry-sdk>=0.26.1',
+        'bravado>=11.0.3'
     ],
     keywords='zipkin',
     classifiers=[

--- a/swagger_zipkin/decorate_client.py
+++ b/swagger_zipkin/decorate_client.py
@@ -44,7 +44,7 @@ class OperationDecorator(Generic[P, T]):
     :type  func: callable
     """
 
-    def __init__(self, operation: Resource, func: Callable[P, T]) -> None:
+    def __init__(self, operation: Operation, func: Callable[P, T]) -> None:
         self.operation = operation
         self.func = func
 
@@ -56,8 +56,8 @@ class OperationDecorator(Generic[P, T]):
 
 
 def decorate_client(
-    api_client: Client,
-    func: Callable[P, T],
+    api_client: Resource,
+    func: Callable[[str, P.args, P.kwargs], T],
     name: str,
 ) -> Resource[P, T]:
     """A helper for decorating :class:`bravado.client.SwaggerClient`.

--- a/swagger_zipkin/otel_decorator.py
+++ b/swagger_zipkin/otel_decorator.py
@@ -56,9 +56,13 @@ class OtelResourceDecorator:
         with tracer.start_as_current_span(
             span_name, kind=trace.SpanKind.CLIENT
         ) as span:
-            inject_otel_headers(kwargs, span)
-            inject_zipkin_headers(kwargs, span, parent_span)
+            self.inject_otel_headers(kwargs, span)
+            self.inject_zipkin_headers(kwargs, span, parent_span)
 
+            # ideally wrap with_headers with exception and catch a specific
+            # exception - HTTPError? and general exception in handle_exception. 
+            # This would create a dependency on bravado package. Is this ok?
+            # https://github.com/Yelp/bravado/blob/master/bravado/exception.py
             with self.handle_exception():
                 span.set_attribute("url.path", getattr(request, "path", ""))
                 span.set_attribute("http.route", http_route)
@@ -120,35 +124,35 @@ class OtelClientDecorator:
         return dir(self._client)  # pragma: no cover
 
 
-def inject_otel_headers(
-    kwargs: dict[str, Any], current_span: trace.Span
-) -> None:
-    propagator = TraceContextTextMapPropagator()
-    carrier = kwargs['_request_options']["headers"]
-    propagator.inject(carrier=carrier, context=trace.set_span_in_context(current_span))
+    def inject_otel_headers(
+        self, kwargs: dict[str, Any], current_span: trace.Span
+    ) -> None:
+        propagator = TraceContextTextMapPropagator()
+        carrier = kwargs['_request_options']["headers"]
+        propagator.inject(carrier=carrier, context=trace.set_span_in_context(current_span))
 
 
-def inject_zipkin_headers(
-        kwargs: dict[str, Any], current_span: trace.Span, parent_span: trace.Span
-) -> None:
-    current_span_context = current_span.get_span_context()
-    kwargs["_request_options"]["headers"]["X-B3-TraceId"] = format_trace_id(
-        current_span_context.trace_id
-    )
-    kwargs["_request_options"]["headers"]["X-B3-SpanId"] = format_span_id(
-        current_span_context.span_id
-    )
-    if parent_span is not None and parent_span.is_recording():
-        parent_span_context = parent_span.get_span_context()
-        kwargs["_request_options"]["headers"]["X-B3-ParentSpanId"] = format_span_id(
-        parent_span_context.span_id)
+    def inject_zipkin_headers(
+            self, kwargs: dict[str, Any], current_span: trace.Span, parent_span: trace.Span
+    ) -> None:
+        current_span_context = current_span.get_span_context()
+        kwargs["_request_options"]["headers"]["X-B3-TraceId"] = format_trace_id(
+            current_span_context.trace_id
+        )
+        kwargs["_request_options"]["headers"]["X-B3-SpanId"] = format_span_id(
+            current_span_context.span_id
+        )
+        if parent_span is not None and parent_span.is_recording():
+            parent_span_context = parent_span.get_span_context()
+            kwargs["_request_options"]["headers"]["X-B3-ParentSpanId"] = format_span_id(
+            parent_span_context.span_id)
 
-    kwargs["_request_options"]["headers"]["X-B3-Sampled"] = (
-        "1"
-        if (current_span_context.trace_flags & TraceFlags.SAMPLED == TraceFlags.SAMPLED)
-        else "0"
-    )
-    kwargs["_request_options"]["headers"]["X-B3-Flags"] = "0"
+        kwargs["_request_options"]["headers"]["X-B3-Sampled"] = (
+            "1"
+            if (current_span_context.trace_flags & TraceFlags.SAMPLED == TraceFlags.SAMPLED)
+            else "0"
+        )
+        kwargs["_request_options"]["headers"]["X-B3-Flags"] = "0"
 
 
 # pragma: no cover

--- a/swagger_zipkin/otel_decorator.py
+++ b/swagger_zipkin/otel_decorator.py
@@ -47,7 +47,7 @@ class OtelResourceDecorator:
 
             operation = getattr(self.resource, call_name)
             request = construct_request(operation, request_options, **kwargs)  # type: ignore
-            
+
             url = getattr(request, "url", "")
             path = getattr(request, "path", "")
             method = getattr(request, "method", "")
@@ -85,7 +85,7 @@ class OtelResourceDecorator:
         try:
             yield
         except Exception as e:
-            # not raising an exception if the instrumentation had a problem 
+            # not raising an exception if the instrumentation had a problem
             raise e
 
     def __dir__(self) -> list[str]:

--- a/swagger_zipkin/otel_decorator.py
+++ b/swagger_zipkin/otel_decorator.py
@@ -123,8 +123,8 @@ class OtelResourceDecorator:
 
 
 class OtelClientDecorator:
-    """A wrapper to swagger client (swagger-py or bravado) to pass on zipkin
-    headers to the service call.
+    """A wrapper to swagger client (swagger-py or bravado) to pass on otel and zipkin
+    headers to the service call. It will also generate a CLIENT span for the outgoing call.
 
     Even though client is initialised once, all the calls made will have
     independent spans.

--- a/swagger_zipkin/otel_decorator.py
+++ b/swagger_zipkin/otel_decorator.py
@@ -18,8 +18,7 @@ from swagger_zipkin.decorate_client import decorate_client
 from swagger_zipkin.decorate_client import Resource
 
 if TYPE_CHECKING:
-    # pragma: no cover
-    import pyramid.request.Request  # type: ignore[import-untyped]
+    import pyramid.request.Request   # noqa: F401  
 
 T = TypeVar('T', covariant=True)
 P = ParamSpec('P')
@@ -47,6 +46,9 @@ class OtelResourceDecorator:
         request_options: dict = kwargs['_request_options']
         request_options.setdefault('headers', {})
 
+        # what is the right way to get the Request object. can we use contruct_request
+        # https://github.com/Yelp/bravado/blob/master/bravado/client.py#L283C5-L283C22
+        # this would create a bravado dependency. 
         request = get_pyramid_current_request()
         http_route = getattr(request, "matched_route", "")
         http_request_method = getattr(request, "method", "")
@@ -155,10 +157,6 @@ class OtelClientDecorator:
         return dir(self._client)  # pragma: no cover
 
 
-
-
-
-# pragma: no cover
 def get_pyramid_current_request() -> pyramid.request.Request | None:
     try:
         threadlocal = importlib.import_module("pyramid.threadlocal")

--- a/swagger_zipkin/otel_decorator.py
+++ b/swagger_zipkin/otel_decorator.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import importlib
 from contextlib import contextmanager
 from typing import Any
-from typing import TYPE_CHECKING
 from typing import TypeVar
 
+from bravado.client import construct_request
+from bravado.exception import HTTPError
 from opentelemetry import trace
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 from opentelemetry.trace.span import format_span_id
@@ -16,9 +16,6 @@ from typing_extensions import ParamSpec
 from swagger_zipkin.decorate_client import Client
 from swagger_zipkin.decorate_client import decorate_client
 from swagger_zipkin.decorate_client import Resource
-
-if TYPE_CHECKING:
-    import pyramid.request.Request   # type: ignore # noqa: F401
 
 T = TypeVar('T', covariant=True)
 P = ParamSpec('P')
@@ -33,7 +30,7 @@ class OtelResourceDecorator:
     :type resource: :class:`swaggerpy.client.Resource` or :class:`bravado_core.resource.Resource`
     """
 
-    def __init__(self, resource: Client, client_identifier: str, smartstack_namespace: str) -> None:
+    def __init__(self, resource: Resource, client_identifier: str, smartstack_namespace: str) -> None:
         self.resource = resource
         self.client_identifier = client_identifier
         self.smartstack_namespace = smartstack_namespace
@@ -42,41 +39,44 @@ class OtelResourceDecorator:
         return decorate_client(self.resource, self.with_headers, name)
 
     def with_headers(self, call_name: str, *args: Any, **kwargs: Any) -> Any:
-        kwargs.setdefault('_request_options', {})
-        request_options: dict = kwargs['_request_options']
-        request_options.setdefault('headers', {})
 
-        # what is the right way to get the Request object. can we use contruct_request
-        # https://github.com/Yelp/bravado/blob/master/bravado/client.py#L283C5-L283C22
-        # this would create a bravado dependency.
-        request = get_pyramid_current_request()
-        http_route = getattr(request, "matched_route", "")
-        http_request_method = getattr(request, "method", "")
+        with self.handle_exception():
+            kwargs.setdefault('_request_options', {})
+            request_options: dict = kwargs['_request_options']
+            request_options.setdefault('headers', {})
 
-        parent_span = trace.get_current_span()
-        span_name = f"{http_request_method} {http_route}"
-        with tracer.start_as_current_span(
-            span_name, kind=trace.SpanKind.CLIENT
-        ) as span:
-            self.inject_otel_headers(kwargs, span)
-            self.inject_zipkin_headers(kwargs, span, parent_span)
+            operation = getattr(self.resource, call_name)
+            request = construct_request(operation, request_options, **kwargs)  # type: ignore
+            
+            url = getattr(request, "url", "")
+            path = getattr(request, "path", "")
+            method = getattr(request, "method", "")
 
-            # ideally the exception should be scoped for self.with_headers
-            # handle_exception should handle general excetion and the specific exception HTTPError
-            # But this would create a dependency on bravado package. Is this ok?
-            # Assuming resource.operation does throw HTTPError
-            # https://github.com/Yelp/bravado/blob/master/bravado/exception.py
-            with self.handle_exception():
-                span.set_attribute("url.path", getattr(request, "path", ""))
-                span.set_attribute("http.route", http_route)
-                span.set_attribute("http.request.method", http_request_method)
+            parent_span = trace.get_current_span()
+            span_name = f"{method} {path}"
 
+            with tracer.start_as_current_span(
+                span_name, kind=trace.SpanKind.CLIENT
+            ) as span:
+                span.set_attribute("url.path", url)
+                span.set_attribute("http.request.method", method)
                 span.set_attribute("client.namespace", self.client_identifier)
                 span.set_attribute("peer.service", self.smartstack_namespace)
                 span.set_attribute("server.namespace", self.smartstack_namespace)
                 span.set_attribute("http.response.status_code", "200")
 
-                return getattr(self.resource, call_name)(*args, **kwargs)
+                self.inject_otel_headers(kwargs, span)
+                self.inject_zipkin_headers(kwargs, span, parent_span)
+
+                try:
+                    operation(*args, **kwargs)
+                except HTTPError as e:
+                    span.set_attribute("error.type", e.__class__.__name__)
+                    span.set_status(trace.Status(trace.StatusCode.ERROR, e.message))
+                    span.set_attribute("http.response.status_code", e.status_code)
+                    raise e
+
+                return operation
 
     @contextmanager
     def handle_exception(
@@ -85,9 +85,7 @@ class OtelResourceDecorator:
         try:
             yield
         except Exception as e:
-            span = trace.get_current_span()
-            span.set_attribute("error.type", e.__class__.__name__)
-            span.set_attribute("http.response.status_code", "500")
+            # not raising an exception if the instrumentation had a problem 
             raise e
 
     def __dir__(self) -> list[str]:
@@ -154,12 +152,3 @@ class OtelClientDecorator:
 
     def __dir__(self) -> list[str]:
         return dir(self._client)  # pragma: no cover
-
-
-def get_pyramid_current_request() -> pyramid.request.Request | None:
-    try:
-        threadlocal = importlib.import_module("pyramid.threadlocal")
-    except ImportError:
-        return None
-
-    return threadlocal.get_current_request()

--- a/swagger_zipkin/otel_decorator.py
+++ b/swagger_zipkin/otel_decorator.py
@@ -1,30 +1,28 @@
 from __future__ import annotations
 
-import os
 import importlib
 
 from typing import Any
-from typing import TYPE_CHECKING
 from typing import TypeVar
 
 from opentelemetry import trace
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
-from opentelemetry.trace.span import TraceFlags
 from opentelemetry.trace.span import format_span_id
 from opentelemetry.trace.span import format_trace_id
-
+from opentelemetry.trace.span import TraceFlags
 from typing_extensions import ParamSpec
 
 from swagger_zipkin.decorate_client import Client
 from swagger_zipkin.decorate_client import decorate_client
 from swagger_zipkin.decorate_client import Resource
+# from typing import TYPE_CHECKING
 
 
 T = TypeVar('T', covariant=True)
 P = ParamSpec('P')
 
-if TYPE_CHECKING:
-    import pyramid.request.Request  # type: ignore
+# if TYPE_CHECKING:
+import pyramid.request.Request  # type: ignore
 
 tracer = trace.get_tracer("otel_decorator")
 
@@ -52,15 +50,15 @@ class OtelResourceDecorator:
         request = get_pyramid_current_request()
         http_route = getattr(request, "matched_route", "")
         http_request_method = getattr(request, "method", "")
-        
+
         span_name = f"{http_request_method} {http_route}"
         with tracer.start_as_current_span(
             span_name, kind=trace.SpanKind.CLIENT
-        ) as span:   
+        ) as span:
             span.set_attribute("url.path", getattr(request, "path", ""))
             span.set_attribute("http.route", http_route)
             span.set_attribute("http.request.method", http_request_method)
-        
+
             span.set_attribute("client.namespace", self.client_identifier)
             span.set_attribute("peer.service", self.smartstack_namespace)
             span.set_attribute("server.namespace", self.smartstack_namespace)
@@ -125,11 +123,7 @@ def inject_zipkin_headers(
     kwargs["_request_options"]["headers"]["X-B3-SpanId"] = format_span_id(
         current_span_context.span_id
     )
-    parent_span = current_span.parent
-    if parent_span is not None:
-        kwargs["_request_options"]["headers"]["X-B3-ParentSpanId"] = format_span_id(
-            parent_span.span_id
-        )
+
     kwargs["_request_options"]["headers"]["X-B3-Sampled"] = (
         "1"
         if (current_span_context.trace_flags & TraceFlags.SAMPLED == TraceFlags.SAMPLED)

--- a/swagger_zipkin/otel_decorator.py
+++ b/swagger_zipkin/otel_decorator.py
@@ -11,7 +11,6 @@ from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapProp
 from opentelemetry.trace.span import format_span_id
 from opentelemetry.trace.span import format_trace_id
 from opentelemetry.trace.span import TraceFlags
-
 from typing_extensions import ParamSpec
 
 from swagger_zipkin.decorate_client import Client
@@ -33,6 +32,7 @@ class OtelResourceDecorator:
     :param resource: A resource object. eg. `client.pet`, `client.store`.
     :type resource: :class:`swaggerpy.client.Resource` or :class:`bravado_core.resource.Resource`
     """
+
     def __init__(self, resource: Client, client_identifier: str, smartstack_namespace: str) -> None:
         self.resource = resource
         self.client_identifier = client_identifier
@@ -55,19 +55,19 @@ class OtelResourceDecorator:
             span_name, kind=trace.SpanKind.CLIENT
         ) as span:
             with self.handle_exception():
-               span.set_attribute("url.path", getattr(request, "path", ""))
-               span.set_attribute("http.route", http_route)
-               span.set_attribute("http.request.method", http_request_method)
+                span.set_attribute("url.path", getattr(request, "path", ""))
+                span.set_attribute("http.route", http_route)
+                span.set_attribute("http.request.method", http_request_method)
 
-               span.set_attribute("client.namespace", self.client_identifier)
-               span.set_attribute("peer.service", self.smartstack_namespace)
-               span.set_attribute("server.namespace", self.smartstack_namespace)
-               span.set_attribute("http.response.status_code", "200")
+                span.set_attribute("client.namespace", self.client_identifier)
+                span.set_attribute("peer.service", self.smartstack_namespace)
+                span.set_attribute("server.namespace", self.smartstack_namespace)
+                span.set_attribute("http.response.status_code", "200")
 
-               inject_otel_headers(kwargs, current_span=span)
-               inject_zipkin_headers(kwargs, current_span=span)
+                inject_otel_headers(kwargs, current_span=span)
+                inject_zipkin_headers(kwargs, current_span=span)
 
-               return getattr(self.resource, call_name)(*args, **kwargs)
+                return getattr(self.resource, call_name)(*args, **kwargs)
 
     @contextmanager
     def handle_exception(
@@ -82,7 +82,7 @@ class OtelResourceDecorator:
             raise e
 
     def __dir__(self) -> list[str]:
-        return dir(self.resource)
+        return dir(self.resource)  # pragma: no cover
 
 
 class OtelClientDecorator:

--- a/swagger_zipkin/otel_decorator.py
+++ b/swagger_zipkin/otel_decorator.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import os
+import importlib
+
+from typing import Any
+from typing import TYPE_CHECKING
+from typing import TypeVar
+
+from opentelemetry import trace
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+from opentelemetry.trace.span import TraceFlags
+from opentelemetry.trace.span import format_span_id
+from opentelemetry.trace.span import format_trace_id
+
+from typing_extensions import ParamSpec
+
+from swagger_zipkin.decorate_client import Client
+from swagger_zipkin.decorate_client import decorate_client
+from swagger_zipkin.decorate_client import Resource
+
+
+T = TypeVar('T', covariant=True)
+P = ParamSpec('P')
+
+if TYPE_CHECKING:
+    import pyramid.request.Request  # type: ignore
+
+tracer = trace.get_tracer("otel_decorator")
+
+
+class OtelResourceDecorator:
+    """A wrapper to the swagger resource.
+
+    :param resource: A resource object. eg. `client.pet`, `client.store`.
+    :type resource: :class:`swaggerpy.client.Resource` or :class:`bravado_core.resource.Resource`
+    """
+
+    def __init__(self, resource: Client, client_identifier: str, smartstack_namespace: str) -> None:
+        self.resource = resource
+        self.client_identifier = client_identifier
+        self.smartstack_namespace = smartstack_namespace
+
+    def __getattr__(self, name: str) -> Resource:
+        return decorate_client(self.resource, self.with_headers, name)
+
+    def with_headers(self, call_name: str, *args: Any, **kwargs: Any) -> Any:
+        kwargs.setdefault('_request_options', {})
+        request_options: dict = kwargs['_request_options']
+        request_options.setdefault('headers', {})
+
+        request = get_pyramid_current_request()
+        http_route = getattr(request, "matched_route", "")
+        http_request_method = getattr(request, "method", "")
+        
+        span_name = f"{http_request_method} {http_route}"
+        with tracer.start_as_current_span(
+            span_name, kind=trace.SpanKind.CLIENT
+        ) as span:   
+            span.set_attribute("url.path", getattr(request, "path", ""))
+            span.set_attribute("http.route", http_route)
+            span.set_attribute("http.request.method", http_request_method)
+        
+            span.set_attribute("client.namespace", self.client_identifier)
+            span.set_attribute("peer.service", self.smartstack_namespace)
+            span.set_attribute("server.namespace", self.smartstack_namespace)
+
+            inject_otel_headers(kwargs, current_span=span)
+            inject_zipkin_headers(kwargs, current_span=span)
+
+            return getattr(self.resource, call_name)(*args, **kwargs)
+
+    def __dir__(self) -> list[str]:
+        return dir(self.resource)
+
+
+class OtelClientDecorator:
+    """A wrapper to swagger client (swagger-py or bravado) to pass on zipkin
+    headers to the service call.
+
+    Even though client is initialised once, all the calls made will have
+    independent spans.
+
+    :param client: Swagger Client
+    :type client: :class:`swaggerpy.client.SwaggerClient` or :class:`bravado.client.SwaggerClient`.
+    :param client_identifier: the name of the service that is using this
+            generated clientlib
+    :type client_identifier: string
+    :param smartstack_namespace: the smartstack name of the paasta instance
+            this generated clientlib is hitting
+    :type smartstack_namespace: string
+    """
+
+    def __init__(self, client: Client, client_identifier: str, smartstack_namespace: str):
+        self._client = client
+        self.client_identifier = client_identifier
+        self.smartstack_namespace = smartstack_namespace
+
+    def __getattr__(self, name: str) -> Client:
+        return OtelResourceDecorator(
+            getattr(self._client, name),
+            client_identifier=self.client_identifier,
+            smartstack_namespace=self.smartstack_namespace,
+        )
+
+    def __dir__(self) -> list[str]:
+        return dir(self._client)  # pragma: no cover
+
+
+def inject_otel_headers(
+    kwargs: dict[str, Any], current_span: trace.Span
+) -> None:
+    propagator = TraceContextTextMapPropagator()
+    carrier = kwargs['_request_options']["headers"]
+    propagator.inject(carrier=carrier, context=trace.set_span_in_context(current_span))
+
+
+def inject_zipkin_headers(
+    kwargs: dict[str, Any], current_span: trace.Span
+) -> None:
+    current_span_context = current_span.get_span_context()
+    kwargs["_request_options"]["headers"]["X-B3-TraceId"] = format_trace_id(
+        current_span_context.trace_id
+    )
+    kwargs["_request_options"]["headers"]["X-B3-SpanId"] = format_span_id(
+        current_span_context.span_id
+    )
+    parent_span = current_span.parent
+    if parent_span is not None:
+        kwargs["_request_options"]["headers"]["X-B3-ParentSpanId"] = format_span_id(
+            parent_span.span_id
+        )
+    kwargs["_request_options"]["headers"]["X-B3-Sampled"] = (
+        "1"
+        if (current_span_context.trace_flags & TraceFlags.SAMPLED == TraceFlags.SAMPLED)
+        else "0"
+    )
+    kwargs["_request_options"]["headers"]["X-B3-Flags"] = "0"
+
+
+def get_pyramid_current_request() -> pyramid.request.Request | None:
+    try:
+        threadlocal = importlib.import_module("pyramid.threadlocal")
+    except ImportError:
+        return None
+
+    return threadlocal.get_current_request()

--- a/swagger_zipkin/otel_decorator.py
+++ b/swagger_zipkin/otel_decorator.py
@@ -51,12 +51,13 @@ class OtelResourceDecorator:
         http_route = getattr(request, "matched_route", "")
         http_request_method = getattr(request, "method", "")
 
+        parent_span = trace.get_current_span()
         span_name = f"{http_request_method} {http_route}"
         with tracer.start_as_current_span(
             span_name, kind=trace.SpanKind.CLIENT
         ) as span:
-            inject_otel_headers(kwargs, current_span=span)
-            inject_zipkin_headers(kwargs, current_span=span)
+            inject_otel_headers(kwargs, span)
+            inject_zipkin_headers(kwargs, span, parent_span)
 
             with self.handle_exception():
                 span.set_attribute("url.path", getattr(request, "path", ""))
@@ -128,7 +129,7 @@ def inject_otel_headers(
 
 
 def inject_zipkin_headers(
-    kwargs: dict[str, Any], current_span: trace.Span
+        kwargs: dict[str, Any], current_span: trace.Span, parent_span: trace.Span
 ) -> None:
     current_span_context = current_span.get_span_context()
     kwargs["_request_options"]["headers"]["X-B3-TraceId"] = format_trace_id(
@@ -137,6 +138,10 @@ def inject_zipkin_headers(
     kwargs["_request_options"]["headers"]["X-B3-SpanId"] = format_span_id(
         current_span_context.span_id
     )
+    if parent_span is not None and parent_span.is_recording():
+        parent_span_context = parent_span.get_span_context()
+        kwargs["_request_options"]["headers"]["X-B3-ParentSpanId"] = format_span_id(
+        parent_span_context.span_id)
 
     kwargs["_request_options"]["headers"]["X-B3-Sampled"] = (
         "1"

--- a/swagger_zipkin/otel_decorator.py
+++ b/swagger_zipkin/otel_decorator.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import importlib
-
 from typing import Any
+from typing import TYPE_CHECKING
 from typing import TypeVar
 
 from opentelemetry import trace
@@ -15,14 +15,13 @@ from typing_extensions import ParamSpec
 from swagger_zipkin.decorate_client import Client
 from swagger_zipkin.decorate_client import decorate_client
 from swagger_zipkin.decorate_client import Resource
-# from typing import TYPE_CHECKING
 
 
 T = TypeVar('T', covariant=True)
 P = ParamSpec('P')
 
-# if TYPE_CHECKING:
-import pyramid.request.Request  # type: ignore
+if TYPE_CHECKING:
+    import pyramid.request.Request  # type: ignore
 
 tracer = trace.get_tracer("otel_decorator")
 
@@ -62,6 +61,7 @@ class OtelResourceDecorator:
             span.set_attribute("client.namespace", self.client_identifier)
             span.set_attribute("peer.service", self.smartstack_namespace)
             span.set_attribute("server.namespace", self.smartstack_namespace)
+            span.set_attribute("http.response.status_code", "200")
 
             inject_otel_headers(kwargs, current_span=span)
             inject_zipkin_headers(kwargs, current_span=span)

--- a/swagger_zipkin/otel_decorator.py
+++ b/swagger_zipkin/otel_decorator.py
@@ -59,9 +59,10 @@ class OtelResourceDecorator:
             self.inject_otel_headers(kwargs, span)
             self.inject_zipkin_headers(kwargs, span, parent_span)
 
-            # ideally wrap with_headers with exception and catch a specific
-            # exception - HTTPError? and general exception in handle_exception. 
-            # This would create a dependency on bravado package. Is this ok?
+            # ideally the exception should be scoped for self.with_headers 
+            # handle_exception should handle general excetion and the specific exception HTTPError 
+            # But this would create a dependency on bravado package. Is this ok?
+            # Assuming resource.operation does throw HTTPError
             # https://github.com/Yelp/bravado/blob/master/bravado/exception.py
             with self.handle_exception():
                 span.set_attribute("url.path", getattr(request, "path", ""))
@@ -89,6 +90,36 @@ class OtelResourceDecorator:
 
     def __dir__(self) -> list[str]:
         return dir(self.resource)  # pragma: no cover
+
+    def inject_otel_headers(
+        self, kwargs: dict[str, Any], current_span: trace.Span
+    ) -> None:
+        propagator = TraceContextTextMapPropagator()
+        carrier = kwargs['_request_options']["headers"]
+        propagator.inject(carrier=carrier, context=trace.set_span_in_context(current_span))
+
+
+    def inject_zipkin_headers(
+            self, kwargs: dict[str, Any], current_span: trace.Span, parent_span: trace.Span
+    ) -> None:
+        current_span_context = current_span.get_span_context()
+        kwargs["_request_options"]["headers"]["X-B3-TraceId"] = format_trace_id(
+            current_span_context.trace_id
+        )
+        kwargs["_request_options"]["headers"]["X-B3-SpanId"] = format_span_id(
+            current_span_context.span_id
+        )
+        if parent_span is not None and parent_span.is_recording():
+            parent_span_context = parent_span.get_span_context()
+            kwargs["_request_options"]["headers"]["X-B3-ParentSpanId"] = format_span_id(
+            parent_span_context.span_id)
+
+        kwargs["_request_options"]["headers"]["X-B3-Sampled"] = (
+            "1"
+            if (current_span_context.trace_flags & TraceFlags.SAMPLED == TraceFlags.SAMPLED)
+            else "0"
+        )
+        kwargs["_request_options"]["headers"]["X-B3-Flags"] = "0"
 
 
 class OtelClientDecorator:
@@ -124,35 +155,7 @@ class OtelClientDecorator:
         return dir(self._client)  # pragma: no cover
 
 
-    def inject_otel_headers(
-        self, kwargs: dict[str, Any], current_span: trace.Span
-    ) -> None:
-        propagator = TraceContextTextMapPropagator()
-        carrier = kwargs['_request_options']["headers"]
-        propagator.inject(carrier=carrier, context=trace.set_span_in_context(current_span))
 
-
-    def inject_zipkin_headers(
-            self, kwargs: dict[str, Any], current_span: trace.Span, parent_span: trace.Span
-    ) -> None:
-        current_span_context = current_span.get_span_context()
-        kwargs["_request_options"]["headers"]["X-B3-TraceId"] = format_trace_id(
-            current_span_context.trace_id
-        )
-        kwargs["_request_options"]["headers"]["X-B3-SpanId"] = format_span_id(
-            current_span_context.span_id
-        )
-        if parent_span is not None and parent_span.is_recording():
-            parent_span_context = parent_span.get_span_context()
-            kwargs["_request_options"]["headers"]["X-B3-ParentSpanId"] = format_span_id(
-            parent_span_context.span_id)
-
-        kwargs["_request_options"]["headers"]["X-B3-Sampled"] = (
-            "1"
-            if (current_span_context.trace_flags & TraceFlags.SAMPLED == TraceFlags.SAMPLED)
-            else "0"
-        )
-        kwargs["_request_options"]["headers"]["X-B3-Flags"] = "0"
 
 
 # pragma: no cover

--- a/swagger_zipkin/otel_decorator.py
+++ b/swagger_zipkin/otel_decorator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+from contextlib import contextmanager
 from typing import Any
 from typing import TYPE_CHECKING
 from typing import TypeVar
@@ -10,18 +11,18 @@ from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapProp
 from opentelemetry.trace.span import format_span_id
 from opentelemetry.trace.span import format_trace_id
 from opentelemetry.trace.span import TraceFlags
+
 from typing_extensions import ParamSpec
 
 from swagger_zipkin.decorate_client import Client
 from swagger_zipkin.decorate_client import decorate_client
 from swagger_zipkin.decorate_client import Resource
 
+if TYPE_CHECKING:
+    import pyramid.request.Request  # type: ignore
 
 T = TypeVar('T', covariant=True)
 P = ParamSpec('P')
-
-if TYPE_CHECKING:
-    import pyramid.request.Request  # type: ignore
 
 tracer = trace.get_tracer("otel_decorator")
 
@@ -32,7 +33,6 @@ class OtelResourceDecorator:
     :param resource: A resource object. eg. `client.pet`, `client.store`.
     :type resource: :class:`swaggerpy.client.Resource` or :class:`bravado_core.resource.Resource`
     """
-
     def __init__(self, resource: Client, client_identifier: str, smartstack_namespace: str) -> None:
         self.resource = resource
         self.client_identifier = client_identifier
@@ -54,19 +54,32 @@ class OtelResourceDecorator:
         with tracer.start_as_current_span(
             span_name, kind=trace.SpanKind.CLIENT
         ) as span:
-            span.set_attribute("url.path", getattr(request, "path", ""))
-            span.set_attribute("http.route", http_route)
-            span.set_attribute("http.request.method", http_request_method)
+            with self.handle_exception():
+               span.set_attribute("url.path", getattr(request, "path", ""))
+               span.set_attribute("http.route", http_route)
+               span.set_attribute("http.request.method", http_request_method)
 
-            span.set_attribute("client.namespace", self.client_identifier)
-            span.set_attribute("peer.service", self.smartstack_namespace)
-            span.set_attribute("server.namespace", self.smartstack_namespace)
-            span.set_attribute("http.response.status_code", "200")
+               span.set_attribute("client.namespace", self.client_identifier)
+               span.set_attribute("peer.service", self.smartstack_namespace)
+               span.set_attribute("server.namespace", self.smartstack_namespace)
+               span.set_attribute("http.response.status_code", "200")
 
-            inject_otel_headers(kwargs, current_span=span)
-            inject_zipkin_headers(kwargs, current_span=span)
+               inject_otel_headers(kwargs, current_span=span)
+               inject_zipkin_headers(kwargs, current_span=span)
 
-            return getattr(self.resource, call_name)(*args, **kwargs)
+               return getattr(self.resource, call_name)(*args, **kwargs)
+
+    @contextmanager
+    def handle_exception(
+        self,
+    ) -> Any:
+        try:
+            yield
+        except Exception as e:
+            span = trace.get_current_span()
+            span.set_attribute("error.type", e.__class__.__name__)
+            span.set_attribute("http.response.status_code", "500")
+            raise e
 
     def __dir__(self) -> list[str]:
         return dir(self.resource)

--- a/swagger_zipkin/otel_decorator.py
+++ b/swagger_zipkin/otel_decorator.py
@@ -18,7 +18,7 @@ from swagger_zipkin.decorate_client import decorate_client
 from swagger_zipkin.decorate_client import Resource
 
 if TYPE_CHECKING:
-    import pyramid.request.Request   # noqa: F401  
+    import pyramid.request.Request   # type: ignore # noqa: F401
 
 T = TypeVar('T', covariant=True)
 P = ParamSpec('P')
@@ -48,7 +48,7 @@ class OtelResourceDecorator:
 
         # what is the right way to get the Request object. can we use contruct_request
         # https://github.com/Yelp/bravado/blob/master/bravado/client.py#L283C5-L283C22
-        # this would create a bravado dependency. 
+        # this would create a bravado dependency.
         request = get_pyramid_current_request()
         http_route = getattr(request, "matched_route", "")
         http_request_method = getattr(request, "method", "")
@@ -61,8 +61,8 @@ class OtelResourceDecorator:
             self.inject_otel_headers(kwargs, span)
             self.inject_zipkin_headers(kwargs, span, parent_span)
 
-            # ideally the exception should be scoped for self.with_headers 
-            # handle_exception should handle general excetion and the specific exception HTTPError 
+            # ideally the exception should be scoped for self.with_headers
+            # handle_exception should handle general excetion and the specific exception HTTPError
             # But this would create a dependency on bravado package. Is this ok?
             # Assuming resource.operation does throw HTTPError
             # https://github.com/Yelp/bravado/blob/master/bravado/exception.py
@@ -100,7 +100,6 @@ class OtelResourceDecorator:
         carrier = kwargs['_request_options']["headers"]
         propagator.inject(carrier=carrier, context=trace.set_span_in_context(current_span))
 
-
     def inject_zipkin_headers(
             self, kwargs: dict[str, Any], current_span: trace.Span, parent_span: trace.Span
     ) -> None:
@@ -114,7 +113,7 @@ class OtelResourceDecorator:
         if parent_span is not None and parent_span.is_recording():
             parent_span_context = parent_span.get_span_context()
             kwargs["_request_options"]["headers"]["X-B3-ParentSpanId"] = format_span_id(
-            parent_span_context.span_id)
+                parent_span_context.span_id)
 
         kwargs["_request_options"]["headers"]["X-B3-Sampled"] = (
             "1"

--- a/swagger_zipkin/otel_decorator.py
+++ b/swagger_zipkin/otel_decorator.py
@@ -18,7 +18,8 @@ from swagger_zipkin.decorate_client import decorate_client
 from swagger_zipkin.decorate_client import Resource
 
 if TYPE_CHECKING:
-    import pyramid.request.Request  # type: ignore
+    # pragma: no cover
+    import pyramid.request.Request  # type: ignore[import-untyped]
 
 T = TypeVar('T', covariant=True)
 P = ParamSpec('P')
@@ -54,6 +55,9 @@ class OtelResourceDecorator:
         with tracer.start_as_current_span(
             span_name, kind=trace.SpanKind.CLIENT
         ) as span:
+            inject_otel_headers(kwargs, current_span=span)
+            inject_zipkin_headers(kwargs, current_span=span)
+
             with self.handle_exception():
                 span.set_attribute("url.path", getattr(request, "path", ""))
                 span.set_attribute("http.route", http_route)
@@ -63,9 +67,6 @@ class OtelResourceDecorator:
                 span.set_attribute("peer.service", self.smartstack_namespace)
                 span.set_attribute("server.namespace", self.smartstack_namespace)
                 span.set_attribute("http.response.status_code", "200")
-
-                inject_otel_headers(kwargs, current_span=span)
-                inject_zipkin_headers(kwargs, current_span=span)
 
                 return getattr(self.resource, call_name)(*args, **kwargs)
 
@@ -145,6 +146,7 @@ def inject_zipkin_headers(
     kwargs["_request_options"]["headers"]["X-B3-Flags"] = "0"
 
 
+# pragma: no cover
 def get_pyramid_current_request() -> pyramid.request.Request | None:
     try:
         threadlocal = importlib.import_module("pyramid.threadlocal")

--- a/swagger_zipkin/zipkin_decorator.py
+++ b/swagger_zipkin/zipkin_decorator.py
@@ -22,7 +22,7 @@ class ZipkinResourceDecorator:
     :type resource: :class:`swaggerpy.client.Resource` or :class:`bravado_core.resource.Resource`
     """
 
-    def __init__(self, resource: Client, context_stack: Stack | None = None) -> None:
+    def __init__(self, resource: Resource, context_stack: Stack | None = None) -> None:
         self.resource = resource
         self._context_stack = context_stack
 

--- a/tests/otel_decorator_test.py
+++ b/tests/otel_decorator_test.py
@@ -7,7 +7,6 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from opentelemetry.trace.span import format_span_id
 from opentelemetry.trace.span import format_trace_id
 
-from swagger_zipkin.decorate_client import Client
 from swagger_zipkin.otel_decorator import OtelClientDecorator
 
 memory_exporter = InMemorySpanExporter()
@@ -28,7 +27,6 @@ def create_request_options(parent_span: trace.Span, exported_span: trace.Span):
             'traceparent': f'00-{trace_id}-{span_id}-01',
             'X-B3-TraceId': format_trace_id(parent_span.get_span_context().trace_id),
             'X-B3-SpanId': format_span_id(exported_span.get_span_context().span_id),
-            'X-B3-ParentSpanId': format_span_id(parent_span.get_span_context().span_id),
             'X-B3-Flags': '0',
             'X-B3-Sampled': '1',
         }
@@ -36,10 +34,10 @@ def create_request_options(parent_span: trace.Span, exported_span: trace.Span):
 
 
 def test_client_request():
-    client = mock.Mock(spec=Client)
+    client = mock.Mock()
     wrapped_client = OtelClientDecorator(
         client,
-        client_identifier=client_identifier, 
+        client_identifier=client_identifier,
         smartstack_namespace=smartstack_namespace
     )
 
@@ -64,4 +62,4 @@ def test_client_request():
         assert exported_span.attributes["client.namespace"] == client_identifier
         assert exported_span.attributes["peer.service"] == smartstack_namespace
         assert exported_span.attributes["server.namespace"] == smartstack_namespace
-        #assert exported_span.attributes["http.response.status_code"] == ""
+        assert exported_span.attributes["http.response.status_code"] == "200"

--- a/tests/otel_decorator_test.py
+++ b/tests/otel_decorator_test.py
@@ -1,0 +1,68 @@
+from unittest import mock
+
+import os
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace.span import format_span_id
+from opentelemetry.trace.span import format_trace_id
+
+from swagger_zipkin.decorate_client import Client
+from swagger_zipkin.otel_decorator import OtelClientDecorator
+
+memory_exporter = InMemorySpanExporter()
+span_processor = SimpleSpanProcessor(memory_exporter)
+trace.set_tracer_provider(TracerProvider())
+trace.get_tracer_provider().add_span_processor(span_processor)
+
+client_identifier = "test_client"
+smartstack_namespace = "smartstack_namespace"
+tracer = trace.get_tracer("otel_decorator")
+
+def create_request_options(parent_span: trace.Span, exported_span: trace.Span):
+    trace_id = format_trace_id(parent_span.get_span_context().trace_id)
+    span_id = format_span_id(exported_span.get_span_context().span_id)
+    return {
+        'headers': {
+            'traceparent': f'00-{trace_id}-{span_id}-01',
+            'X-B3-TraceId': format_trace_id(parent_span.get_span_context().trace_id),
+            'X-B3-SpanId': format_span_id(exported_span.get_span_context().span_id),
+            'X-B3-ParentSpanId': format_span_id(parent_span.get_span_context().span_id),
+            'X-B3-Flags': '0',
+            'X-B3-Sampled': '1',
+        }
+    }
+
+def test_client_request():
+    client = mock.Mock()
+    wrapped_client = OtelClientDecorator(
+        client, client_identifier=client_identifier, smartstack_namespace=smartstack_namespace
+    )
+    
+    with tracer.start_as_current_span(
+        "parent_span", kind=trace.SpanKind.SERVER
+    ) as parent_span:
+        resource = wrapped_client.resource
+        param = mock.Mock()
+        resource.operation(param)
+               
+        assert len(memory_exporter.get_finished_spans()) == 1
+        exported_span = memory_exporter.get_finished_spans()[0]
+                
+        client.resource.operation.assert_called_with(
+            param,
+            _request_options=create_request_options(parent_span, exported_span)
+        )
+        
+        assert exported_span.attributes["url.path"] == ""
+        assert exported_span.attributes["http.request.method"] == ""
+        assert exported_span.attributes["http.route"] == ""
+        assert exported_span.attributes["client.namespace"] == client_identifier
+        assert exported_span.attributes["peer.service"] == smartstack_namespace
+        assert exported_span.attributes["server.namespace"] == smartstack_namespace
+        #assert exported_span.attributes["http.response.status_code"] == ""
+
+
+

--- a/tests/otel_decorator_test.py
+++ b/tests/otel_decorator_test.py
@@ -1,7 +1,5 @@
 from unittest import mock
 
-import os
-
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -21,6 +19,7 @@ client_identifier = "test_client"
 smartstack_namespace = "smartstack_namespace"
 tracer = trace.get_tracer("otel_decorator")
 
+
 def create_request_options(parent_span: trace.Span, exported_span: trace.Span):
     trace_id = format_trace_id(parent_span.get_span_context().trace_id)
     span_id = format_span_id(exported_span.get_span_context().span_id)
@@ -35,27 +34,30 @@ def create_request_options(parent_span: trace.Span, exported_span: trace.Span):
         }
     }
 
+
 def test_client_request():
-    client = mock.Mock()
+    client = mock.Mock(spec=Client)
     wrapped_client = OtelClientDecorator(
-        client, client_identifier=client_identifier, smartstack_namespace=smartstack_namespace
+        client,
+        client_identifier=client_identifier, 
+        smartstack_namespace=smartstack_namespace
     )
-    
+
     with tracer.start_as_current_span(
         "parent_span", kind=trace.SpanKind.SERVER
     ) as parent_span:
         resource = wrapped_client.resource
         param = mock.Mock()
         resource.operation(param)
-               
+
         assert len(memory_exporter.get_finished_spans()) == 1
         exported_span = memory_exporter.get_finished_spans()[0]
-                
+
         client.resource.operation.assert_called_with(
             param,
             _request_options=create_request_options(parent_span, exported_span)
         )
-        
+
         assert exported_span.attributes["url.path"] == ""
         assert exported_span.attributes["http.request.method"] == ""
         assert exported_span.attributes["http.route"] == ""
@@ -63,6 +65,3 @@ def test_client_request():
         assert exported_span.attributes["peer.service"] == smartstack_namespace
         assert exported_span.attributes["server.namespace"] == smartstack_namespace
         #assert exported_span.attributes["http.response.status_code"] == ""
-
-
-

--- a/tests/otel_decorator_test.py
+++ b/tests/otel_decorator_test.py
@@ -22,6 +22,11 @@ tracer = trace.get_tracer("otel_decorator")
 
 
 @pytest.fixture
+def setup():
+    memory_exporter.clear()
+
+
+@pytest.fixture
 def get_request():
     mock_request = mock.Mock()
     mock_request.path = "/sample-url"
@@ -51,7 +56,7 @@ def create_request_options(parent_span: trace.Span, exported_span: trace.Span):
 @mock.patch(
     "swagger_zipkin.otel_decorator.get_pyramid_current_request", autospec=True
 )
-def test_client_request(mock_request, get_request):
+def test_client_request(mock_request, get_request, setup):
     mock_request.return_value = get_request
 
     with tracer.start_as_current_span(
@@ -84,13 +89,11 @@ def test_client_request(mock_request, get_request):
         assert exported_span.attributes["server.namespace"] == smartstack_namespace
         assert exported_span.attributes["http.response.status_code"] == "200"
 
-    memory_exporter.clear()
-
 
 @mock.patch(
     "swagger_zipkin.otel_decorator.get_pyramid_current_request", autospec=True
 )
-def test_client_request_no_parent_span(mock_request, get_request):
+def test_client_request_no_parent_span(mock_request, get_request, setup):
     mock_request.return_value = get_request
 
     client = mock.Mock()
@@ -120,13 +123,11 @@ def test_client_request_no_parent_span(mock_request, get_request):
     assert exported_span.attributes["server.namespace"] == smartstack_namespace
     assert exported_span.attributes["http.response.status_code"] == "200"
 
-    memory_exporter.clear()
-
 
 @mock.patch(
     "swagger_zipkin.otel_decorator.get_pyramid_current_request", autospec=True
 )
-def test_with_headers_exception(mock_request, get_request):
+def test_with_headers_exception(mock_request, get_request, setup):
     mock_request.return_value = get_request
 
     # Create a mock resource and configure it to raise an exception
@@ -151,5 +152,3 @@ def test_with_headers_exception(mock_request, get_request):
     assert exported_span.attributes["peer.service"] == smartstack_namespace
     assert exported_span.attributes["server.namespace"] == smartstack_namespace
     assert exported_span.attributes["http.response.status_code"] == "500"
-
-    memory_exporter.clear()

--- a/tests/otel_decorator_test.py
+++ b/tests/otel_decorator_test.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import pytest
 from opentelemetry import trace
+from opentelemetry.trace import SpanKind
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
@@ -80,6 +81,7 @@ def test_client_request(mock_request, get_request, setup):
             _request_options=create_request_options(parent_span, exported_span)
         )
 
+        assert exported_span.kind == SpanKind.CLIENT
         assert exported_span.name == f"{get_request.method} {get_request.matched_route}"
         assert exported_span.attributes["url.path"] == get_request.path
         assert exported_span.attributes["http.request.method"] == get_request.method
@@ -136,6 +138,7 @@ def test_client_request_no_parent_span(mock_request, get_request, setup):
         _request_options=create_request_options(None, exported_span)
     )
 
+    assert exported_span.kind == SpanKind.CLIENT
     assert exported_span.name == f"{get_request.method} {get_request.matched_route}"
     assert exported_span.attributes["url.path"] == get_request.path
     assert exported_span.attributes["http.request.method"] == get_request.method
@@ -174,6 +177,7 @@ def test_with_headers_exception(mock_request, get_request, setup):
     actual_headers = create_request_options(None, exported_span)['headers']
     assert expected_headers == actual_headers
 
+    assert exported_span.kind == SpanKind.CLIENT
     assert exported_span.name == f"{get_request.method} {get_request.matched_route}"
     assert exported_span.attributes["url.path"] == get_request.path
     assert exported_span.attributes["http.request.method"] == get_request.method

--- a/tests/otel_decorator_test.py
+++ b/tests/otel_decorator_test.py
@@ -9,6 +9,7 @@ from opentelemetry.trace.span import format_span_id
 from opentelemetry.trace.span import format_trace_id
 
 from swagger_zipkin.otel_decorator import OtelClientDecorator
+from swagger_zipkin.otel_decorator import OtelResourceDecorator
 
 memory_exporter = InMemorySpanExporter()
 span_processor = SimpleSpanProcessor(memory_exporter)
@@ -49,16 +50,15 @@ def create_request_options(parent_span: trace.Span, exported_span: trace.Span):
 def test_client_request(mock_request, get_request):
     mock_request.return_value = get_request
 
-    client = mock.Mock()
-    wrapped_client = OtelClientDecorator(
-        client,
-        client_identifier=client_identifier,
-        smartstack_namespace=smartstack_namespace
-    )
-
     with tracer.start_as_current_span(
         "parent_span", kind=trace.SpanKind.SERVER
     ) as parent_span:
+        client = mock.Mock()
+        wrapped_client = OtelClientDecorator(
+            client,
+            client_identifier=client_identifier,
+            smartstack_namespace=smartstack_namespace
+        )
         resource = wrapped_client.resource
         param = mock.Mock()
         resource.operation(param)
@@ -79,3 +79,37 @@ def test_client_request(mock_request, get_request):
         assert exported_span.attributes["peer.service"] == smartstack_namespace
         assert exported_span.attributes["server.namespace"] == smartstack_namespace
         assert exported_span.attributes["http.response.status_code"] == "200"
+
+    memory_exporter.clear()
+
+
+@mock.patch(
+    "swagger_zipkin.otel_decorator.get_pyramid_current_request", autospec=True
+)
+def test_with_headers_exception(mock_request, get_request):
+    mock_request.return_value = get_request
+
+    # Create a mock resource and configure it to raise an exception
+    mock_resource = mock.MagicMock()
+    mock_method = mock.MagicMock(side_effect=Exception("Simulated exception"))
+    setattr(mock_resource, 'test_call', mock_method)
+
+    decorator = OtelResourceDecorator(resource=mock_resource, client_identifier="test_client",
+                                      smartstack_namespace="smartstack_namespace")
+
+    with pytest.raises(Exception):
+        decorator.with_headers("test_call")
+
+    assert len(memory_exporter.get_finished_spans()) == 1
+    exported_span = memory_exporter.get_finished_spans()[0]
+
+    assert exported_span.name == f"{get_request.method} {get_request.matched_route}"
+    assert exported_span.attributes["url.path"] == get_request.path
+    assert exported_span.attributes["http.request.method"] == get_request.method
+    assert exported_span.attributes["http.route"] == get_request.matched_route
+    assert exported_span.attributes["client.namespace"] == client_identifier
+    assert exported_span.attributes["peer.service"] == smartstack_namespace
+    assert exported_span.attributes["server.namespace"] == smartstack_namespace
+    assert exported_span.attributes["http.response.status_code"] == "500"
+
+    memory_exporter.clear()

--- a/tests/otel_decorator_test.py
+++ b/tests/otel_decorator_test.py
@@ -12,6 +12,9 @@ from opentelemetry.trace.span import format_trace_id
 from swagger_zipkin.otel_decorator import OtelClientDecorator
 from swagger_zipkin.otel_decorator import OtelResourceDecorator
 
+from bravado.exception import HTTPError
+from bravado.exception import HTTPInternalServerError
+
 memory_exporter = InMemorySpanExporter()
 span_processor = SimpleSpanProcessor(memory_exporter)
 trace.set_tracer_provider(TracerProvider())
@@ -30,9 +33,9 @@ def setup():
 @pytest.fixture
 def get_request():
     mock_request = mock.Mock()
+    mock_request.url = "/sample-url"
     mock_request.path = "/sample-url"
     mock_request.method = "GET"
-    mock_request.matched_route = "sample-view"
     return mock_request
 
 
@@ -55,7 +58,7 @@ def create_request_options(parent_span: trace.Span, exported_span: trace.Span):
 
 
 @mock.patch(
-    "swagger_zipkin.otel_decorator.get_pyramid_current_request", autospec=True
+    "swagger_zipkin.otel_decorator.construct_request", autospec=True
 )
 def test_client_request(mock_request, get_request, setup):
     mock_request.return_value = get_request
@@ -82,10 +85,9 @@ def test_client_request(mock_request, get_request, setup):
         )
 
         assert exported_span.kind == SpanKind.CLIENT
-        assert exported_span.name == f"{get_request.method} {get_request.matched_route}"
+        assert exported_span.name == f"{get_request.method} {get_request.path}"
         assert exported_span.attributes["url.path"] == get_request.path
         assert exported_span.attributes["http.request.method"] == get_request.method
-        assert exported_span.attributes["http.route"] == get_request.matched_route
         assert exported_span.attributes["client.namespace"] == client_identifier
         assert exported_span.attributes["peer.service"] == smartstack_namespace
         assert exported_span.attributes["server.namespace"] == smartstack_namespace
@@ -102,10 +104,9 @@ def test_client_request(mock_request, get_request, setup):
             _request_options=create_request_options(parent_span, exported_span)
         )
 
-        assert exported_span.name == f"{get_request.method} {get_request.matched_route}"
+        assert exported_span.name == f"{get_request.method} {get_request.path}"
         assert exported_span.attributes["url.path"] == get_request.path
         assert exported_span.attributes["http.request.method"] == get_request.method
-        assert exported_span.attributes["http.route"] == get_request.matched_route
         assert exported_span.attributes["client.namespace"] == client_identifier
         assert exported_span.attributes["peer.service"] == smartstack_namespace
         assert exported_span.attributes["server.namespace"] == smartstack_namespace
@@ -113,7 +114,7 @@ def test_client_request(mock_request, get_request, setup):
 
 
 @mock.patch(
-    "swagger_zipkin.otel_decorator.get_pyramid_current_request", autospec=True
+    "swagger_zipkin.otel_decorator.construct_request", autospec=True
 )
 def test_client_request_no_parent_span(mock_request, get_request, setup):
     mock_request.return_value = get_request
@@ -137,10 +138,9 @@ def test_client_request_no_parent_span(mock_request, get_request, setup):
     )
 
     assert exported_span.kind == SpanKind.CLIENT
-    assert exported_span.name == f"{get_request.method} {get_request.matched_route}"
+    assert exported_span.name == f"{get_request.method} {get_request.path}"
     assert exported_span.attributes["url.path"] == get_request.path
     assert exported_span.attributes["http.request.method"] == get_request.method
-    assert exported_span.attributes["http.route"] == get_request.matched_route
     assert exported_span.attributes["client.namespace"] == client_identifier
     assert exported_span.attributes["peer.service"] == smartstack_namespace
     assert exported_span.attributes["server.namespace"] == smartstack_namespace
@@ -148,24 +148,25 @@ def test_client_request_no_parent_span(mock_request, get_request, setup):
 
 
 @mock.patch(
-    "swagger_zipkin.otel_decorator.get_pyramid_current_request", autospec=True
+    "swagger_zipkin.otel_decorator.construct_request", autospec=True
 )
 def test_with_headers_exception(mock_request, get_request, setup):
     mock_request.return_value = get_request
 
     # Create a mock resource and configure it to raise an exception
     mock_resource = mock.MagicMock()
-    mock_method = mock.MagicMock(side_effect=Exception("simulated exception"))
+    mock_response = mock.MagicMock()
+    mock_response.status_code = "500"
+    mock_method = mock.MagicMock(side_effect=HTTPInternalServerError(response=mock_response))
     setattr(mock_resource, 'test_operation', mock_method)
 
     decorator = OtelResourceDecorator(resource=mock_resource, client_identifier="test_client",
                                       smartstack_namespace="smartstack_namespace")
 
-    # Prepare arguments
     args = ()
     kwargs = {'_request_options': {'headers': {}}}
-
-    with pytest.raises(Exception):
+    
+    with pytest.raises(HTTPError):
         decorator.with_headers("test_operation", *args, **kwargs)
 
     assert len(memory_exporter.get_finished_spans()) == 1
@@ -176,12 +177,11 @@ def test_with_headers_exception(mock_request, get_request, setup):
     assert expected_headers == actual_headers
 
     assert exported_span.kind == SpanKind.CLIENT
-    assert exported_span.name == f"{get_request.method} {get_request.matched_route}"
+    assert exported_span.name == f"{get_request.method} {get_request.path}"
     assert exported_span.attributes["url.path"] == get_request.path
     assert exported_span.attributes["http.request.method"] == get_request.method
-    assert exported_span.attributes["http.route"] == get_request.matched_route
     assert exported_span.attributes["client.namespace"] == client_identifier
     assert exported_span.attributes["peer.service"] == smartstack_namespace
     assert exported_span.attributes["server.namespace"] == smartstack_namespace
-    assert exported_span.attributes["error.type"] == "Exception"
+    assert exported_span.attributes["error.type"] == "HTTPInternalServerError"
     assert exported_span.attributes["http.response.status_code"] == "500"

--- a/tests/otel_decorator_test.py
+++ b/tests/otel_decorator_test.py
@@ -69,14 +69,14 @@ def test_client_request(mock_request, get_request, setup):
             smartstack_namespace=smartstack_namespace
         )
         resource = wrapped_client.resource
-        param = mock.Mock()
-        resource.operation(param)
+        param1 = mock.Mock()
+        resource.operation(param1)
 
         assert len(memory_exporter.get_finished_spans()) == 1
         exported_span = memory_exporter.get_finished_spans()[0]
 
         client.resource.operation.assert_called_with(
-            param,
+            param1,
             _request_options=create_request_options(parent_span, exported_span)
         )
 
@@ -88,6 +88,28 @@ def test_client_request(mock_request, get_request, setup):
         assert exported_span.attributes["peer.service"] == smartstack_namespace
         assert exported_span.attributes["server.namespace"] == smartstack_namespace
         assert exported_span.attributes["http.response.status_code"] == "200"
+
+        param2 = mock.Mock()
+        resource.operation(param2)
+
+        assert len(memory_exporter.get_finished_spans()) == 2
+        exported_span = memory_exporter.get_finished_spans()[1]
+
+        client.resource.operation.assert_called_with(
+            param2,
+            _request_options=create_request_options(parent_span, exported_span)
+        )
+
+        assert exported_span.name == f"{get_request.method} {get_request.matched_route}"
+        assert exported_span.attributes["url.path"] == get_request.path
+        assert exported_span.attributes["http.request.method"] == get_request.method
+        assert exported_span.attributes["http.route"] == get_request.matched_route
+        assert exported_span.attributes["client.namespace"] == client_identifier
+        assert exported_span.attributes["peer.service"] == smartstack_namespace
+        assert exported_span.attributes["server.namespace"] == smartstack_namespace
+        assert exported_span.attributes["http.response.status_code"] == "200"
+
+
 
 
 @mock.patch(
@@ -133,16 +155,22 @@ def test_with_headers_exception(mock_request, get_request, setup):
     # Create a mock resource and configure it to raise an exception
     mock_resource = mock.MagicMock()
     mock_method = mock.MagicMock(side_effect=Exception("Simulated exception"))
-    setattr(mock_resource, 'test_call', mock_method)
+    setattr(mock_resource, 'test_operation', mock_method)
 
     decorator = OtelResourceDecorator(resource=mock_resource, client_identifier="test_client",
                                       smartstack_namespace="smartstack_namespace")
 
     with pytest.raises(Exception):
-        decorator.with_headers("test_call")
+        decorator.with_headers("test_operation")
+
 
     assert len(memory_exporter.get_finished_spans()) == 1
     exported_span = memory_exporter.get_finished_spans()[0]
+
+    mock_resource.operation.assert_called_with(
+        "test_operation",
+        _request_options=create_request_options(None, exported_span)
+    )
 
     assert exported_span.name == f"{get_request.method} {get_request.matched_route}"
     assert exported_span.attributes["url.path"] == get_request.path
@@ -151,4 +179,5 @@ def test_with_headers_exception(mock_request, get_request, setup):
     assert exported_span.attributes["client.namespace"] == client_identifier
     assert exported_span.attributes["peer.service"] == smartstack_namespace
     assert exported_span.attributes["server.namespace"] == smartstack_namespace
+    assert exported_span.attributes["error.type"] == "Exception" 
     assert exported_span.attributes["http.response.status_code"] == "500"

--- a/tests/otel_decorator_test.py
+++ b/tests/otel_decorator_test.py
@@ -1,5 +1,6 @@
 from unittest import mock
 
+import pytest
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -19,6 +20,15 @@ smartstack_namespace = "smartstack_namespace"
 tracer = trace.get_tracer("otel_decorator")
 
 
+@pytest.fixture
+def get_request():
+    mock_request = mock.Mock()
+    mock_request.path = "/sample-url"
+    mock_request.method = "GET"
+    mock_request.matched_route = "sample-view"
+    return mock_request
+
+
 def create_request_options(parent_span: trace.Span, exported_span: trace.Span):
     trace_id = format_trace_id(parent_span.get_span_context().trace_id)
     span_id = format_span_id(exported_span.get_span_context().span_id)
@@ -33,7 +43,12 @@ def create_request_options(parent_span: trace.Span, exported_span: trace.Span):
     }
 
 
-def test_client_request():
+@mock.patch(
+    "swagger_zipkin.otel_decorator.get_pyramid_current_request", autospec=True
+)
+def test_client_request(mock_request, get_request):
+    mock_request.return_value = get_request
+
     client = mock.Mock()
     wrapped_client = OtelClientDecorator(
         client,
@@ -56,9 +71,10 @@ def test_client_request():
             _request_options=create_request_options(parent_span, exported_span)
         )
 
-        assert exported_span.attributes["url.path"] == ""
-        assert exported_span.attributes["http.request.method"] == ""
-        assert exported_span.attributes["http.route"] == ""
+        assert exported_span.name == f"{get_request.method} {get_request.matched_route}"
+        assert exported_span.attributes["url.path"] == get_request.path
+        assert exported_span.attributes["http.request.method"] == get_request.method
+        assert exported_span.attributes["http.route"] == get_request.matched_route
         assert exported_span.attributes["client.namespace"] == client_identifier
         assert exported_span.attributes["peer.service"] == smartstack_namespace
         assert exported_span.attributes["server.namespace"] == smartstack_namespace

--- a/tests/otel_decorator_test.py
+++ b/tests/otel_decorator_test.py
@@ -2,10 +2,10 @@ from unittest import mock
 
 import pytest
 from opentelemetry import trace
-from opentelemetry.trace import SpanKind
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import SpanKind
 from opentelemetry.trace.span import format_span_id
 from opentelemetry.trace.span import format_trace_id
 
@@ -50,7 +50,7 @@ def create_request_options(parent_span: trace.Span, exported_span: trace.Span):
     }
     if parent_span is not None:
         headers['headers']['X-B3-ParentSpanId'] = format_span_id(parent_span.get_span_context().span_id)
-    
+
     return headers
 
 
@@ -110,8 +110,6 @@ def test_client_request(mock_request, get_request, setup):
         assert exported_span.attributes["peer.service"] == smartstack_namespace
         assert exported_span.attributes["server.namespace"] == smartstack_namespace
         assert exported_span.attributes["http.response.status_code"] == "200"
-
-
 
 
 @mock.patch(
@@ -185,5 +183,5 @@ def test_with_headers_exception(mock_request, get_request, setup):
     assert exported_span.attributes["client.namespace"] == client_identifier
     assert exported_span.attributes["peer.service"] == smartstack_namespace
     assert exported_span.attributes["server.namespace"] == smartstack_namespace
-    assert exported_span.attributes["error.type"] == "Exception" 
+    assert exported_span.attributes["error.type"] == "Exception"
     assert exported_span.attributes["http.response.status_code"] == "500"

--- a/tests/otel_decorator_test.py
+++ b/tests/otel_decorator_test.py
@@ -1,6 +1,8 @@
 from unittest import mock
 
 import pytest
+from bravado.exception import HTTPError
+from bravado.exception import HTTPInternalServerError
 from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -11,9 +13,6 @@ from opentelemetry.trace.span import format_trace_id
 
 from swagger_zipkin.otel_decorator import OtelClientDecorator
 from swagger_zipkin.otel_decorator import OtelResourceDecorator
-
-from bravado.exception import HTTPError
-from bravado.exception import HTTPInternalServerError
 
 memory_exporter = InMemorySpanExporter()
 span_processor = SimpleSpanProcessor(memory_exporter)
@@ -165,7 +164,7 @@ def test_with_headers_exception(mock_request, get_request, setup):
 
     args = ()
     kwargs = {'_request_options': {'headers': {}}}
-    
+
     with pytest.raises(HTTPError):
         decorator.with_headers("test_operation", *args, **kwargs)
 

--- a/tests/otel_decorator_test.py
+++ b/tests/otel_decorator_test.py
@@ -31,17 +31,21 @@ def get_request():
 
 
 def create_request_options(parent_span: trace.Span, exported_span: trace.Span):
-    trace_id = format_trace_id(parent_span.get_span_context().trace_id)
+    trace_id = format_trace_id(exported_span.get_span_context().trace_id)
     span_id = format_span_id(exported_span.get_span_context().span_id)
-    return {
-        'headers': {
-            'traceparent': f'00-{trace_id}-{span_id}-01',
-            'X-B3-TraceId': format_trace_id(parent_span.get_span_context().trace_id),
-            'X-B3-SpanId': format_span_id(exported_span.get_span_context().span_id),
-            'X-B3-Flags': '0',
-            'X-B3-Sampled': '1',
-        }
+
+    headers = {}
+    headers['headers'] = {
+        'traceparent': f'00-{trace_id}-{span_id}-01',
+        'X-B3-TraceId': trace_id,
+        'X-B3-SpanId': span_id,
+        'X-B3-Flags': '0',
+        'X-B3-Sampled': '1',
     }
+    if parent_span is not None:
+        headers['headers']['X-B3-ParentSpanId'] = format_span_id(parent_span.get_span_context().span_id)
+    
+    return headers
 
 
 @mock.patch(
@@ -79,6 +83,42 @@ def test_client_request(mock_request, get_request):
         assert exported_span.attributes["peer.service"] == smartstack_namespace
         assert exported_span.attributes["server.namespace"] == smartstack_namespace
         assert exported_span.attributes["http.response.status_code"] == "200"
+
+    memory_exporter.clear()
+
+
+@mock.patch(
+    "swagger_zipkin.otel_decorator.get_pyramid_current_request", autospec=True
+)
+def test_client_request_no_parent_span(mock_request, get_request):
+    mock_request.return_value = get_request
+
+    client = mock.Mock()
+    wrapped_client = OtelClientDecorator(
+        client,
+        client_identifier=client_identifier,
+        smartstack_namespace=smartstack_namespace
+    )
+    resource = wrapped_client.resource
+    param = mock.Mock()
+    resource.operation(param)
+
+    assert len(memory_exporter.get_finished_spans()) == 1
+    exported_span = memory_exporter.get_finished_spans()[0]
+
+    client.resource.operation.assert_called_with(
+        param,
+        _request_options=create_request_options(None, exported_span)
+    )
+
+    assert exported_span.name == f"{get_request.method} {get_request.matched_route}"
+    assert exported_span.attributes["url.path"] == get_request.path
+    assert exported_span.attributes["http.request.method"] == get_request.method
+    assert exported_span.attributes["http.route"] == get_request.matched_route
+    assert exported_span.attributes["client.namespace"] == client_identifier
+    assert exported_span.attributes["peer.service"] == smartstack_namespace
+    assert exported_span.attributes["server.namespace"] == smartstack_namespace
+    assert exported_span.attributes["http.response.status_code"] == "200"
 
     memory_exporter.clear()
 

--- a/tests/otel_decorator_test.py
+++ b/tests/otel_decorator_test.py
@@ -154,23 +154,25 @@ def test_with_headers_exception(mock_request, get_request, setup):
 
     # Create a mock resource and configure it to raise an exception
     mock_resource = mock.MagicMock()
-    mock_method = mock.MagicMock(side_effect=Exception("Simulated exception"))
+    mock_method = mock.MagicMock(side_effect=Exception("simulated exception"))
     setattr(mock_resource, 'test_operation', mock_method)
 
     decorator = OtelResourceDecorator(resource=mock_resource, client_identifier="test_client",
                                       smartstack_namespace="smartstack_namespace")
 
-    with pytest.raises(Exception):
-        decorator.with_headers("test_operation")
+    # Prepare arguments
+    args = ()
+    kwargs = {'_request_options': {'headers': {}}}
 
+    with pytest.raises(Exception):
+        decorator.with_headers("test_operation", *args, **kwargs)
 
     assert len(memory_exporter.get_finished_spans()) == 1
     exported_span = memory_exporter.get_finished_spans()[0]
 
-    mock_resource.operation.assert_called_with(
-        "test_operation",
-        _request_options=create_request_options(None, exported_span)
-    )
+    expected_headers = kwargs['_request_options']['headers']
+    actual_headers = create_request_options(None, exported_span)['headers']
+    assert expected_headers == actual_headers
 
     assert exported_span.name == f"{get_request.method} {get_request.matched_route}"
     assert exported_span.attributes["url.path"] == get_request.path


### PR DESCRIPTION
Proposed change to add otel instrumentation as discussed in # 3 [Scope](https://docs.google.com/document/d/1k3MQzLMayc-HiUz-6FyDYjLt5vFr7Y4uBUPpiZkVI58/edit?tab=t.0#heading=h.llhbwrivrtba)

Prior work done for static clientlibs: https://sourcegraph.yelpcorp.com/python-packages/yelp_openapi/-/blob/yelp_openapi/clientlib/otel_tween.py

Note:
1. Did not end up creating a new repo: swagger_otel for this purpose. Wanted to re-use decorate_client.py plus zipkin will go away ideally in next 2-3 quarters and we can rename this repo to swagger_otel if necessary.

2. I've added some comments in the PR where I need help/guidance.